### PR TITLE
Installation on MacOs

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -12,6 +12,11 @@ set(PYTHON_INCLUDE_DIRS __PYTHON_INCLUDE__)
 set(PYTHON_LDFLAGS "__PYTHON_LDFLAGS__")
 set(pele_dir __PELE_INCLUDE__)
 
+# osx makes the suffix for shared object libraries .dylib
+IF(APPLE)
+  SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+ENDIF(APPLE)
+
 # BLAS and LAPACK
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
@@ -87,6 +92,23 @@ FILE(GLOB pele_sources ${PyCG_DESCENT_include}/PyCG_DESCENT/*.cpp)
 FILE(GLOB PyCG_DESCENT_sources ${PyCG_DESCENT_include}/CG_DESCENT/*.c*)
 add_library(PyCG_DESCENT_lib SHARED ${PyCG_DESCENT_sources} ${pele_sources})
 
+# Apple changed the ld linker in Xcode 15 which breaks the build.
+# The classic linker can be chosen with -ld_classic flag.
+# However, on older Xcode versions, this flag throws an error.
+# Thus, we simply check here whether this flag exists.
+# See https://www.scivision.dev/xcode-ld_classic/
+# For the undefined flag, see
+# https://github.com/nasa/cFE/issues/476#issuecomment-579436106
+if(APPLE)
+  include(CheckLinkerFlag)
+  check_linker_flag(C "-ld_classic" CLASSIC_FLAG)
+  if(CLASSIC_FLAG)
+    set(APPLE_LINK_OPTIONS "LINKER:-undefined,dynamic_lookup,-ld_classic")
+  else(CLASSIC_FLAG)
+    set(APPLE_LINK_OPTIONS "LINKER:-undefined,dynamic_lookup")
+  endif(CLASSIC_FLAG)
+endif(APPLE)
+
 function(make_cython_lib cython_cxx_source)
   get_filename_component(library_name ${cython_cxx_source} NAME)
   string(REGEX REPLACE ".cxx$" "" library_name ${library_name})
@@ -94,6 +116,9 @@ function(make_cython_lib cython_cxx_source)
   target_link_libraries(${library_name} PyCG_DESCENT_lib)
   target_link_libraries(${library_name} ${SUNDIALS_LIBRARIES})
   target_link_libraries(${library_name} ${LAPACK_LIBRARIES})
+  if(APPLE)
+    target_link_options(${library_name} PUBLIC ${APPLE_LINK_OPTIONS})
+  endif(APPLE)
   set_target_properties(${library_name} PROPERTIES PREFIX "")
   message("making library ${library_name} from source ${cython_cxx_source}")
 endfunction(make_cython_lib)

--- a/cpp_tests/CMakeLists.txt
+++ b/cpp_tests/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project(pycg_descent)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # if not specified by user, the standard build type is release
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release Coverage." FORCE)
@@ -10,28 +13,42 @@ endif(NOT CMAKE_BUILD_TYPE)
 enable_language(CXX)
 ADD_DEFINITIONS(-O3)
 ADD_DEFINITIONS(-lm)
-ADD_DEFINITIONS(-std=c++0x)
 ADD_DEFINITIONS(-Wall)
 ADD_DEFINITIONS(-g)
 
 #cmake_policy(SET CMP0015 NEW)
 
 # set the cgd include directory
-set(cgd_include /home/sm958/Work/PyCG_DESCENT/source)
+set(cgd_include ../source/CG_DESCENT)
 include_directories(${cgd_include})
 message("cgd include directory ${cgd_include}")
 
 # build the cgd_descent library
-FILE(GLOB cgd_sources ${cgd_include}/CG_DESCENT6.7/*.c*)
+FILE(GLOB cgd_sources ${cgd_include}/*.c*)
 add_library(cgd_lib ${cgd_sources})
 
+set(PELE_DIR ../../pele)
+
 # set the pele include directory
-set(pele_include /home/sm958/Work/pele/source)
+set(pele_include ${PELE_DIR}/source CACHE STRING "the pele c++ source directory")
+
+if(EXISTS ${pele_include}/pele/array.hpp)
+	message("pele include directory: ${pele_include}")
+else()
+	message(FATAL_ERROR "pele include directory is not correct: ${pele_include} : use ccmake to set it")
+endif()
+
+set(PELE_EXTERN_DIR ${PELE_DIR}/extern/install)
+set(EXTERN_INCLUDE_DIR ${PELE_EXTERN_DIR}/include/) # FOR EIGEN, CVODE etc
+set(LAPACKE_INCLUDE_DIR ${PELE_EXTERN_DIR}/include/Eigen/src/misc)
+
 include_directories(${pele_include})
-message("pele include directory ${pele_include}")
+include_directories(../source)
+include_directories(${EXTERN_INCLUDE_DIR})
+include_directories(${LAPACKE_INCLUDE_DIR})
 
 # build the pele library
-FILE(GLOB pele_sources ${pele_include}/*.cpp)
+FILE(GLOB pele_sources ${pele_include}/*.c*)
 add_library(pele_lib ${pele_sources})
 
 ## get all the source files

--- a/cpp_tests/bench_minimization.cpp
+++ b/cpp_tests/bench_minimization.cpp
@@ -3,10 +3,10 @@
 #include <fstream>
 #include <string>
 
-#include "pele/lj.h"
-#include "pele/lbfgs.h"
-#include "pele/matrix.h"
-#include "pele/array.h"
+#include "pele/lj.hpp"
+#include "pele/lbfgs.hpp"
+#include "pele/matrix.hpp"
+#include "pele/array.hpp"
 #include "PyCG_DESCENT/cg_descent_wrapper.hpp"
 
 using std::string;

--- a/setup_with_cmake.py
+++ b/setup_with_cmake.py
@@ -59,10 +59,16 @@ jargs, remaining_args = parser.parse_known_args(sys.argv)
 idcompiler = None
 if not jargs.compiler or jargs.compiler in ("unix", "gnu", "gcc"):
     idcompiler = "unix"
-    remaining_args += ["-c", idcompiler]
+    # Only add command line option back if it was really set
+    # This allows to use setup.py install (which does not allow -c option)
+    if jargs.compiler:
+        remaining_args += ["-c", idcompiler]
 elif jargs.compiler in ("intelem", "intel", "icc", "icpc"):
     idcompiler = "intel"
-    remaining_args += ["-c", idcompiler]
+    # Only add command line option back if it was really set
+    # This allows to use setup.py install (which does not allow -c option)
+    if jargs.compiler:
+        remaining_args += ["-c", idcompiler]
 
 # set the remaining args back as sys.argv
 sys.argv = remaining_args
@@ -196,6 +202,132 @@ class ModuleList(object):
         self.module_list.append(Extension(modname, [filename], **self.kwargs))
 
 
+def get_compiler_env(compiler_id):
+    """
+    set environment variables for the C and C++ compiler:
+    set CC and CXX paths to `which` output because cmake
+    does not alway choose the right compiler
+    """
+    env = os.environ.copy()
+
+    if compiler_id.lower() in ("unix"):
+        print(env, "eeenv")
+        if sys.platform.startswith("darwin"):
+            cc = None
+            version = 20
+            while version > 9:
+                try:
+                    cc = (
+                        (subprocess.check_output(["which", f"gcc-{version}"]))
+                        .decode(encoding)
+                        .rstrip("\n")
+                    )
+                    break
+                except subprocess.CalledProcessError:
+                    version -= 1
+            if version == 9:
+                raise RuntimeError("Could not detect a GNU C compiler "
+                                   "with an executable in the format 'gcc-version' "
+                                   "on your darwin platform (tried versions 10 to "
+                                   "20). Make sure that you installed a GNU C "
+                                   "compiler and that its executable is in one of your "
+                                   "PATH directories.")
+            assert cc is not None
+            env["CC"] = cc
+            env["CXX"] = (
+                (subprocess.check_output(["which", f"g++-{version}"]))
+                .decode(encoding)
+                .rstrip("\n")
+            )
+            # Numpy distutils looks for the F90 environment variable to
+            # determine the Fortran compiler.
+            # See https://stackoverflow.com/questions/55373559/numpy-distutils-specify-intel-fortran-compiler-in-setup-py
+            env["F90"] = (
+                (subprocess.check_output(["which", f"gfortran-{version}"]))
+                .decode(encoding)
+                .rstrip("\n")
+            )
+            # Cmake looks for the FC environment variable to determine
+            # the Fortran compiler.
+            # See https://cmake.org/cmake/help/latest/envvar/FC.html
+            env["FC"] = (
+                (subprocess.check_output(["which", f"gfortran-{version}"]))
+                .decode(encoding)
+                .rstrip("\n")
+            )
+        else:
+            env["CC"] = (
+                (subprocess.check_output(["which", "gcc"]))
+                .decode(encoding)
+                .rstrip("\n")
+            )
+            env["CXX"] = (
+                (subprocess.check_output(["which", "g++"]))
+                .decode(encoding)
+                .rstrip("\n")
+            )
+        env["LD"] = (
+            (subprocess.check_output(["which", "ld"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        env["AR"] = (
+            (subprocess.check_output(["which", "ar"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+    elif compiler_id.lower() in ("intel"):
+        env["CC"] = (
+            (subprocess.check_output(["which", "icc"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        env["CXX"] = (
+            (subprocess.check_output(["which", "icpc"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        env["LD"] = (
+            (subprocess.check_output(["which", "xild"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        env["AR"] = (
+            (subprocess.check_output(["which", "xiar"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+    else:
+        raise Exception("compiler id not known")
+    # this line only works if the build directory has been deleted
+    cmake_compiler_args = shlex.split(
+        "-D CMAKE_EXPORT_COMPILE_COMMANDS=1 "
+        "-D CMAKE_C_COMPILER={} -D CMAKE_CXX_COMPILER={} "
+        "-D CMAKE_LINKER={} -D CMAKE_AR={}".format(
+            env["CC"], env["CXX"], env["LD"], env["AR"]
+        )
+    )
+    # Add search path for brew installed openblas on MacOs.
+    if sys.platform.startswith("darwin"):
+        openblas = (
+            (subprocess.check_output(["brew", "--prefix", "openblas"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        gettext = (
+            (subprocess.check_output(["brew", "--prefix", "gettext"]))
+            .decode(encoding)
+            .rstrip("\n")
+        )
+        cmake_compiler_args.extend(
+            shlex.split(f"-D CMAKE_PREFIX_PATH={openblas};{gettext}"))
+    return env, cmake_compiler_args
+
+
+env, _ = get_compiler_env(idcompiler)
+os.environ = env
+
+
 setup(
     name="PyCG_DESCENT",
     version="0.1",
@@ -234,14 +366,21 @@ def get_ldflags(opt="--ldflags"):
     getvar = sysconfig.get_config_var
     pyver = sysconfig.get_config_var("VERSION")
     libs = getvar("LIBS").split() + getvar("SYSLIBS").split()
-    libs.append("-lpython" + pyver)
+    if not sys.platform.startswith("darwin"):
+        # On MacOs, explicitly including the python library leads to a
+        # segmentation fault when libraries created by cython are
+        # imported
+        libs.append(
+            "-lpython" + pyver
+        )
     # add the prefix/lib/pythonX.Y/config dir, but only if there is no
     # shared library in prefix/lib/.
     if opt == "--ldflags":
         if not getvar("Py_ENABLE_SHARED"):
             libs.insert(0, "-L" + getvar("LIBPL"))
         if not getvar("PYTHONFRAMEWORK"):
-            libs.extend(getvar("LINKFORSHARED").split())
+            # See https://github.com/kovidgoyal/kitty/issues/289#issuecomment-416040645
+            libs.extend(getvar("LINKFORSHARED").replace('-Wl,-stack_size,1000000', '').split())
     return " ".join(libs)
 
 
@@ -272,73 +411,12 @@ with open("CMakeLists.txt", "w") as fout:
         fout.write("make_cython_lib(${CMAKE_SOURCE_DIR}/%s)\n" % fname)
 
 
-def set_compiler_env(compiler_id):
-    """
-    set environment variables for the C and C++ compiler:
-    set CC and CXX paths to `which` output because cmake
-    does not alway choose the right compiler
-    """
-    env = os.environ.copy()
-    if compiler_id.lower() in ("unix"):
-        env["CC"] = (
-            (subprocess.check_output(["which", "gcc"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["CXX"] = (
-            (subprocess.check_output(["which", "g++"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["LD"] = (
-            (subprocess.check_output(["which", "ld"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["AR"] = (
-            (subprocess.check_output(["which", "ar"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-    elif compiler_id.lower() in ("intel"):
-        env["CC"] = (
-            (subprocess.check_output(["which", "icc"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["CXX"] = (
-            (subprocess.check_output(["which", "icpc"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["LD"] = (
-            (subprocess.check_output(["which", "xild"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-        env["AR"] = (
-            (subprocess.check_output(["which", "xiar"]))
-            .decode(encoding)
-            .rstrip("\n")
-        )
-    else:
-        raise Exception("compiler_id not known")
-    # this line only works is the build directory has been deleted
-    cmake_compiler_args = shlex.split(
-        "-D CMAKE_C_COMPILER={} -D CMAKE_CXX_COMPILER={} "
-        "-D CMAKE_LINKER={} -D CMAKE_AR={}".format(
-            env["CC"], env["CXX"], env["LD"], env["AR"]
-        )
-    )
-    return env, cmake_compiler_args
-
-
 def run_cmake(compiler_id="unix"):
     if not os.path.isdir(cmake_build_dir):
         os.makedirs(cmake_build_dir)
     print("\nrunning cmake in directory", cmake_build_dir)
     cwd = os.path.abspath(os.path.dirname(__file__))
-    env, cmake_compiler_args = set_compiler_env(compiler_id)
+    env, cmake_compiler_args = get_compiler_env(compiler_id)
 
     p = subprocess.call(
         ["cmake"] + cmake_compiler_args + [cwd], cwd=cmake_build_dir, env=env


### PR DESCRIPTION
This allows to install PyCG_DESCENT on Macs.

The changes are basically the same as for pele (see pull request #33 there). I only updated the setup_with_cmake.py file, not the setup.py file.

There are no GitHub workflows here but I tested the changes on Intel and on Apple silicon. 

The README.rst file here does not yet talk about the setup_with_cmake.py file, which is why I didn't change anything in the README.rst file. The commands are the same as for the installation for pele.